### PR TITLE
[Study] optimistic_lock 공부

### DIFF
--- a/src/main/java/org/example/oauth2/entity/StockEntity.java
+++ b/src/main/java/org/example/oauth2/entity/StockEntity.java
@@ -3,6 +3,7 @@ package org.example.oauth2.entity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.Version;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,6 +20,9 @@ public class StockEntity {
 
     private Long productId;
     private Long quantity;
+
+    @Version
+    private Long version;
 
     public void decrementQuantity(Long amount) {
         if(this.quantity - amount < 0) {

--- a/src/main/java/org/example/oauth2/facade/OptimisticLockStockFacade.java
+++ b/src/main/java/org/example/oauth2/facade/OptimisticLockStockFacade.java
@@ -1,0 +1,23 @@
+package org.example.oauth2.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.example.oauth2.service.lock.OptimisticLockStockService;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OptimisticLockStockFacade {
+    private final OptimisticLockStockService optimisticLockStockService;
+
+
+    public void decrease(Long id, Long quantity) throws InterruptedException {
+        while (true) {
+            try {
+                optimisticLockStockService.decrease(id, quantity);
+                break;
+            } catch (Exception e) {
+                Thread.sleep(50);
+            }
+        }
+    }
+}

--- a/src/main/java/org/example/oauth2/repository/StockRepository.java
+++ b/src/main/java/org/example/oauth2/repository/StockRepository.java
@@ -13,4 +13,13 @@ public interface StockRepository extends JpaRepository<StockEntity, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select s from StockEntity s where s.id = :id")
     StockEntity findByIdWithPessimisticLock(Long id);
+
+    // 낙관적 락은 데이터 정합성을 유지하면서도 락을 최소화하는 방식
+    // 별도의 락을 잡지 않으므로 성능에 장점이 있지만
+    // 업데이트가 실패했을 때 개발자가 직접 재시도 로직을 구현해야 한다.
+    // 충돌이 빈번하게 일어날거라고 생각한다면 비관적 락을 사용해야한다.
+    // 충돌이란 낙관적 락을 사용하는 트랜잭션들이 동일한 데이터를 동시에 수정하려 할 때 발생하는 버전 불일치 상황
+    @Lock(LockModeType.OPTIMISTIC)
+    @Query("select s from StockEntity s where s.id = :id")
+    StockEntity findByIdWithOptimisticLock(Long id);
 }

--- a/src/main/java/org/example/oauth2/service/lock/OptimisticLockStockService.java
+++ b/src/main/java/org/example/oauth2/service/lock/OptimisticLockStockService.java
@@ -1,0 +1,20 @@
+package org.example.oauth2.service.lock;
+
+import lombok.RequiredArgsConstructor;
+import org.example.oauth2.entity.StockEntity;
+import org.example.oauth2.repository.StockRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OptimisticLockStockService {
+    private final StockRepository stockRepository;
+
+    @Transactional
+    public void decrease(Long id, Long quantity) {
+        StockEntity stock = stockRepository.findByIdWithOptimisticLock(id);
+        stock.decrementQuantity(quantity);
+        stockRepository.save(stock);
+    }
+}

--- a/src/test/java/org/example/oauth2/facade/OptimisticLockStockFacadeTest.java
+++ b/src/test/java/org/example/oauth2/facade/OptimisticLockStockFacadeTest.java
@@ -1,0 +1,67 @@
+package org.example.oauth2.facade;
+
+import org.example.oauth2.entity.StockEntity;
+import org.example.oauth2.repository.StockRepository;
+import org.example.oauth2.service.lock.PessimisticLockStockService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class OptimisticLockStockFacadeTest {
+    @Autowired
+    private OptimisticLockStockFacade optimisticLockStockFacade;
+
+    @Autowired
+    private StockRepository stockRepository;
+
+    @BeforeEach
+    void before() {
+        stockRepository.save(
+                new StockEntity()
+                        .builder()
+                        .productId(1L)
+                        .quantity(100L)
+                        .build());
+    }
+
+    @AfterEach
+    void after() {
+        stockRepository.deleteAll();
+    }
+
+
+    @Test
+    void 동시에_100개의_요청() throws InterruptedException {
+        int threadCount = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(32);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    optimisticLockStockFacade.decrease(1L, 1L);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+
+        StockEntity stockEntity = stockRepository.findById(1L).orElseThrow();
+        // 100 - (1 * 100) = 0
+        assertEquals(0, stockEntity.getQuantity());
+    }
+}


### PR DESCRIPTION
    // 낙관적 락은 데이터 정합성을 유지하면서도 락을 최소화하는 방식
    // 별도의 락을 잡지 않으므로 성능에 장점이 있지만
    // 업데이트가 실패했을 때 개발자가 직접 재시도 로직을 구현해야 한다.
    // 충돌이 빈번하게 일어날거라고 생각한다면 비관적 락을 사용해야한다.
    // 충돌이란 낙관적 락을 사용하는 트랜잭션들이 동일한 데이터를 동시에 수정하려 할 때 발생하는 버전 불일치 상황